### PR TITLE
Do real x86 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ install:
   - cd C:\projects\winusb-driver-generator
   - git submodule update --init --recursive
   - ps: Install-Product node $env:nodejs_version $env:Platform
+  - if %Platform%==x86 (set npm_config_target_arch=ia32) else (set npm_config_target_arch=%Platform%)
   - npm install --build-from-source
   - pip install cpplint
 

--- a/deps/libwdi_build.bat
+++ b/deps/libwdi_build.bat
@@ -2,6 +2,11 @@
 
 set WINDDK_PATH=C:\WinDDK
 
+:: See https://stackoverflow.com/a/3432895
+for /F %%i in ("%1") do set ARCHITECTURE=%%~ni
+if /I %ARCHITECTURE%==x64 set ARCHITECTURE=amd64
+if /I %ARCHITECTURE%==ia32 set ARCHITECTURE=x86
+
 if exist %WINDDK_PATH% goto winddk_exists
 echo Make sure WinDDK is installed in %WINDDK_PATH% 1>&2
 exit /b 1
@@ -32,8 +37,8 @@ type msvc\config.h
 
 :: Fails with the following error if this directory in not in the PATH:
 ::   winnt.h: error C1189: #error: "No Target Architecture"
-if %1==x64 set PATH=%WINDDK_PATH%\%WINDDK_VERSION%\bin\x86\amd64;%PATH%
-if %1==x86 set PATH=%WINDDK_PATH%\%WINDDK_VERSION%\bin\x86\x86;%PATH%
+echo Adding architecture %ARCHITECTURE% to the path
+set PATH=%WINDDK_PATH%\%WINDDK_VERSION%\bin\x86\%ARCHITECTURE%;%PATH%
 
 :: This script builds a static DLL if the "DLL" option is not passed
 wdk_build.cmd no_samples


### PR DESCRIPTION
Even if we set `platform` to `x86`, the Appveyor machine is still
64-bit, causing libwdi to still be built as amd64 when bundled with the
x86 addon.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>