### PR TITLE
chore(package): Install prebuild on rebuild if available

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "configure": "node-gyp configure",
     "build": "node-gyp build",
-    "rebuild": "node-gyp rebuild",
+    "rebuild": "prebuild-install || node-gyp rebuild",
     "lint-js": "eslint *.js",
     "lint-cpp": "cpplint --recursive src",
     "lint": "npm run lint-js && npm run lint-cpp",


### PR DESCRIPTION
This will install a prebuilt native binding on rebuilds,
avoiding requiring the WDK during rebuilds

Change-Type: patch