### PR TITLE
fix(ci): Fix prebuilds on CI

### DIFF
--- a/ci/prebuild-publish.bat
+++ b/ci/prebuild-publish.bat
@@ -2,6 +2,7 @@
 
 if %APPVEYOR_REPO_BRANCH% == master (
   if %GITHUB_TOKEN% neq "" (
-    call node_modules\.bin\prebuild --all --strip -u %GITHUB_TOKEN%
+    call node_modules\.bin\prebuild --strip --runtime electron --target 1.7.11 --target 1.8.2 -u %GITHUB_TOKEN%
+    call node_modules\.bin\prebuild --strip --runtime node --target 9.9.0 --target 8.10.0 --target 6.13.1 -u %GITHUB_TOKEN%
   )
 )

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint-cpp": "cpplint --recursive src",
     "lint": "npm run lint-js && npm run lint-cpp",
     "test": "npm run lint",
-    "install": "prebuild-install || npm run rebuild"
+    "install": "prebuild-install || node-gyp rebuild"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
This reverts to specifying the versions to prebuild for explicitly
again, as prebuilding for Node v9.0.0 fails when using `--all`

Change-Type: patch
Connects To: #19, https://github.com/resin-io-modules/winusb-driver-generator/issues/16