### PR TITLE
fix(binding): Set build_v8_with_gn to fix prebuilding

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,6 @@
 {
+  # See https://github.com/mafintosh/prebuildify/issues/10 for context on `build_v8_with_gn`
+  "build_v8_with_gn": "false",
   "targets": [
     {
       "target_name": "libwdi_configuration",


### PR DESCRIPTION
This defines a variable that's only defined in Node 10's common.gypi
and would otherwise cause node-gyp to fail with "gyp: name 'build_v8_with_gn' is not defined"
(i.e. see [AppVeyor build, Line 1279](https://ci.appveyor.com/project/resin-io/winusb-driver-generator/branch/master/job/wf7qlfvl51m5wg4k#L1279))

Change-Type: patch
Connects To: https://github.com/resin-io-modules/winusb-driver-generator/issues/31