### PR TITLE
fix(ci): Fix build_v8_with_gn when prebuilding

### DIFF
--- a/ci/prebuild-publish.bat
+++ b/ci/prebuild-publish.bat
@@ -2,7 +2,7 @@
 
 if %APPVEYOR_REPO_BRANCH% == master (
   if %GITHUB_TOKEN% neq "" (
-    call node_modules\.bin\prebuild --strip --runtime electron --target 1.7.13 --target 1.8.7 --target 2.0.0 -u %GITHUB_TOKEN%
-    call node_modules\.bin\prebuild --strip --runtime node --target 6.13.1 --target 8.10.0 --target 10.0.0 -u %GITHUB_TOKEN%
+    npm run prebuilds --build_v8_with_gn=false -- --strip --runtime electron --target 1.7.15 --target 1.8.7 --target 2.0.3 -u %GITHUB_TOKEN%
+    npm run prebuilds --build_v8_with_gn=false -- --strip --runtime node --target 6.13.1 --target 8.10.0 --target 10.5.0 -u %GITHUB_TOKEN%
   )
 )

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint-cpp": "cpplint --recursive src",
     "lint": "npm run lint-js && npm run lint-cpp",
     "test": "npm run lint",
-    "install": "prebuild-install || node-gyp rebuild"
+    "install": "prebuild-install || node-gyp rebuild",
+    "prebuilds": "prebuild"
   },
   "author": "Juan Cruz Viotti <juan@resin.io>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Due to unforeseen circumstances, prebuild's node-gyp ignores `build_v8_with_gn`
from the bindings.gyp file, and it needs to be passed to npm / prebuild directly

Change-Type: patch