### PR TITLE
fix(prebuild): Fix prebuild double upload

### DIFF
--- a/ci/prebuild-publish.bat
+++ b/ci/prebuild-publish.bat
@@ -2,7 +2,7 @@
 
 if %APPVEYOR_REPO_BRANCH% == master (
   if %GITHUB_TOKEN% neq "" (
-    npm run prebuilds --build_v8_with_gn=false -- --strip --runtime electron --target 1.7.15 --target 1.8.7 --target 2.0.3 -u %GITHUB_TOKEN%
+    npm run prebuilds --build_v8_with_gn=false -- --strip --runtime electron --target 1.7.15 --target 2.0.3 -u %GITHUB_TOKEN%
     npm run prebuilds --build_v8_with_gn=false -- --strip --runtime node --target 6.13.1 --target 8.10.0 --target 10.5.0 -u %GITHUB_TOKEN%
   )
 )


### PR DESCRIPTION
Electron 1.8.x and 2.0.x have the same module ABI (v57),
causing the uploads to conflict and become reserved, yet not complete,
in turn causing further uploads and downloads to fail for that prebuild.

Change-Type: patch